### PR TITLE
Fix README paths for reader frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@
 │   ├── common/             # Middleware, Guards
 │   └── main.ts, app.module.ts
 │
-├── reader-frontend/         # NextJS trang đọc truyện
+├── web-reader/              # NextJS trang đọc truyện
 ├── admin-frontend/          # Vite React trang quản trị
 ├── .env                     # Biến môi trường toàn hệ thống
 ├── docker-compose.yml       # Khởi chạy toàn bộ hệ thống
-└── webtruyen-architecture-updated.png # Sơ đồ hệ thống
+└── webtruyen-architecture.png # Sơ đồ hệ thống
 ```
 
 ---


### PR DESCRIPTION
## Summary
- update folder list to reference `web-reader`
- replace non-existent `webtruyen-architecture-updated.png` with `webtruyen-architecture.png`

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867405789388328b234b4fc365dbaa4