### PR TITLE
Implement controllable slug case conversion

### DIFF
--- a/backend/src/utils/slugify.spec.ts
+++ b/backend/src/utils/slugify.spec.ts
@@ -1,0 +1,11 @@
+import { slugify } from './slugify';
+
+describe('slugify', () => {
+  it('should lowercase text by default', () => {
+    expect(slugify('Xin Chào Hà Nội!')).toBe('xin-chao-ha-noi');
+  });
+
+  it('should preserve case when lower is false', () => {
+    expect(slugify('Xin Chào Hà Nội!', { lower: false })).toBe('Xin-Chao-Ha-Noi');
+  });
+});

--- a/backend/src/utils/slugify.ts
+++ b/backend/src/utils/slugify.ts
@@ -1,10 +1,11 @@
-export function slugify(text: string, p0?: { lower: boolean; }): string {
-  return text
-    .toLowerCase()
+export function slugify(text: string, options?: { lower?: boolean }): string {
+  const processed = (options?.lower !== false ? text.toLowerCase() : text)
     .normalize('NFD') // bỏ dấu tiếng Việt
     .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-z0-9 ]/g, '')
+    .replace(/[^a-zA-Z0-9 ]/g, '')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-+|-+$/g, '');
+
+  return processed;
 }


### PR DESCRIPTION
## Summary
- adjust slugify to handle optional lowercase conversion
- add basic slugify tests for default lowercase and preserving case

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867405143f0832894bedfcf037e933c