### PR TITLE
Add mobile Google login page

### DIFF
--- a/native-mobile-app/app/_layout.tsx
+++ b/native-mobile-app/app/_layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="google-login" options={{ title: 'Google Login' }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/native-mobile-app/app/google-login.tsx
+++ b/native-mobile-app/app/google-login.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import { Alert, Button } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import { useRouter } from 'expo-router';
+import { ThemedView } from '@/components/ThemedView';
+
+WebBrowser.maybeCompleteAuthSession();
+
+export default function GoogleLoginScreen() {
+  const router = useRouter();
+  const [request, response, promptAsync] = Google.useAuthRequest({
+    iosClientId: 'YOUR_IOS_CLIENT_ID',
+    androidClientId: 'YOUR_ANDROID_CLIENT_ID',
+    webClientId: 'YOUR_WEB_CLIENT_ID',
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const idToken = response.authentication?.idToken;
+      Alert.alert('Google Login', idToken ? 'Token received' : 'No token');
+      router.replace('(tabs)');
+    }
+  }, [response]);
+
+  return (
+    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Button
+        title="Đăng nhập với Google"
+        disabled={!request}
+        onPress={() => promptAsync()}
+      />
+    </ThemedView>
+  );
+}

--- a/native-mobile-app/package.json
+++ b/native-mobile-app/package.json
@@ -28,6 +28,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
     "expo-web-browser": "~14.2.0",
+    "expo-auth-session": "~5.0.5",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",


### PR DESCRIPTION
## Summary
- update mobile package.json to include expo-auth-session
- add new screen for Google login
- register route in mobile layout

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867439ac9048328949a6ddd1b30c222