### PR TITLE
Fix expo router entry

### DIFF
--- a/native-mobile-app/index.js
+++ b/native-mobile-app/index.js
@@ -1,0 +1,2 @@
+import 'react-native-gesture-handler';
+export { default } from 'expo-router/entry';

--- a/native-mobile-app/package.json
+++ b/native-mobile-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-mobile-app",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- fix expo router error by importing `react-native-gesture-handler`
- update package main entry

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674add8f108328b661c6d019947bbf