### PR TITLE
Fix Google redirect URI generation in expo app

### DIFF
--- a/native-mobile-app/app/index.tsx
+++ b/native-mobile-app/app/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { Alert, Button } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
 import * as Google from 'expo-auth-session/providers/google';
+import * as AuthSession from 'expo-auth-session';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { API_BASE_URL } from '@/constants/Api';
@@ -10,7 +11,7 @@ WebBrowser.maybeCompleteAuthSession();
 
 export default function GoogleLoginScreen() {
   const router = useRouter();
-  const redirectUri = Google.makeRedirectUri({ useProxy: true });
+  const redirectUri = AuthSession.makeRedirectUri({ useProxy: true });
   const [request, response, promptAsync] = Google.useAuthRequest({
     iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID ?? 'YOUR_IOS_CLIENT_ID',
     androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID ?? 'YOUR_ANDROID_CLIENT_ID',


### PR DESCRIPTION
## Summary
- import `AuthSession` from `expo-auth-session`
- use `AuthSession.makeRedirectUri` instead of the non-existent method on the `Google` provider

## Testing
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68674c41c7d08328a4a0c9358582e2bf