### PR TITLE
Integrate new Google signin on mobile

### DIFF
--- a/native-mobile-app/app.json
+++ b/native-mobile-app/app.json
@@ -35,7 +35,8 @@
           "resizeMode": "contain",
           "backgroundColor": "#ffffff"
         }
-      ]
+      ],
+      "@react-native-google-signin/google-signin"
     ],
     "experiments": {
       "typedRoutes": true

--- a/native-mobile-app/app/index.tsx
+++ b/native-mobile-app/app/index.tsx
@@ -1,59 +1,44 @@
 import React, { useEffect } from 'react';
 import { Alert, Button } from 'react-native';
-import * as WebBrowser from 'expo-web-browser';
-import * as Google from 'expo-auth-session/providers/google';
-import * as AuthSession from 'expo-auth-session';
+import { GoogleSignin, statusCodes } from '@react-native-google-signin/google-signin';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { API_BASE_URL } from '@/constants/Api';
 
-WebBrowser.maybeCompleteAuthSession();
-const fixedRedirectUri = 'https://auth.expo.io/@vouucac/tangthulau'
-
 export default function GoogleLoginScreen() {
   const router = useRouter();
-  // const redirectUri = AuthSession.makeRedirectUri();
-
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
-    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
-    webClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
-    responseType: 'code',
-    usePKCE: false,
-    redirectUri: fixedRedirectUri,
-  });
 
   useEffect(() => {
-    const handleLogin = async () => {
-      if (response?.type === 'success' && response.params?.code) {
-        try {
-          const res = await fetch(`${API_BASE_URL}/auth/google`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({ code: response.params.code }),
-          });
+    GoogleSignin.configure({
+      webClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
+      iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
+    });
+  }, []);
 
-          if (!res.ok) throw new Error('Login failed');
-
-          Alert.alert('Login successful');
-          router.replace('/home');
-        } catch (err: any) {
-          Alert.alert('Login failed', err.message);
-        }
+  const handleLogin = async () => {
+    try {
+      await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
+      const userInfo = await GoogleSignin.signIn();
+      if (!userInfo.idToken) throw new Error('No idToken returned');
+      const res = await fetch(`${API_BASE_URL}/auth/google`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ idToken: userInfo.idToken }),
+      });
+      if (!res.ok) throw new Error('Login failed');
+      Alert.alert('Login successful');
+      router.replace('/home');
+    } catch (err: any) {
+      if (err.code !== statusCodes.SIGN_IN_CANCELLED) {
+        Alert.alert('Login failed', err.message);
       }
-    };
-
-    handleLogin();
-  }, [response]);
+    }
+  };
 
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Button
-        title="Đăng nhập với Google"
-        disabled={!request}
-        onPress={() => promptAsync()}
-      />
+      <Button title="Đăng nhập với Google" onPress={handleLogin} />
     </ThemedView>
   );
 }

--- a/native-mobile-app/package.json
+++ b/native-mobile-app/package.json
@@ -22,7 +22,6 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.16",
-    "expo-auth-session": "~6.2.1",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.6",
     "expo-crypto": "~14.1.5",


### PR DESCRIPTION
## Summary
- replace Expo AuthSession flow with `@react-native-google-signin/google-signin`
- add google signin plugin in app config
- drop unused `expo-auth-session` dep from mobile package

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867936d78548328a61fbf931642ad9b