### PR TITLE
Fix Google login iOS client ID

### DIFF
--- a/TangThuLauNative/components/GoogleLogin.tsx
+++ b/TangThuLauNative/components/GoogleLogin.tsx
@@ -6,7 +6,7 @@ import { GoogleSignin } from '@react-native-google-signin/google-signin';
 GoogleSignin.configure({
   webClientId: process.env.GOOGLE_CLIENT_ID_FOR_WEB,
   androidClientId: process.env.GOOGLE_CLIENT_ID_FOR_ANDROID,  // Client ID tạo từ Firebase
-  iosClientId: process.env.GOOGLE_CLIENT_ID_FOR_ANDROID,  // Client ID tạo từ Firebase
+  iosClientId: process.env.GOOGLE_CLIENT_ID_FOR_IOS, // Client ID tạo từ Firebase
   offlineAccess: false,
 } as any);
 


### PR DESCRIPTION
## Summary
- correct the iOS client identifier in Google login configuration

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6867f2c9ac288328b06addf94be35249