### PR TITLE
Implement 3-tab navigation

### DIFF
--- a/TangThuLauNative/app/(tabs)/_layout.tsx
+++ b/TangThuLauNative/app/(tabs)/_layout.tsx
@@ -34,17 +34,17 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="search"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={18} name="paperplane.fill" color={color} />,
+          title: 'Search',
+          tabBarIcon: ({ color }) => <IconSymbol size={18} name="magnifyingglass" color={color} />,
         }}
       />
       <Tabs.Screen
-        name="profile"
+        name="settings"
         options={{
-          title: 'Profile',
-          tabBarIcon: ({ color }) => <IconSymbol size={18} name="0.square.fill.hi" color={color} />,
+          title: 'Settings',
+          tabBarIcon: ({ color }) => <IconSymbol size={18} name="gearshape.fill" color={color} />,
         }}
       />
     </Tabs>

--- a/TangThuLauNative/app/(tabs)/index.tsx
+++ b/TangThuLauNative/app/(tabs)/index.tsx
@@ -36,9 +36,9 @@ export default function HomeScreen() {
         </ThemedText>
       </ThemedView>
       <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
+        <ThemedText type="subtitle">Step 2: Search</ThemedText>
         <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
+          {`Tap the Search tab to learn more about what's included in this starter app.`}
         </ThemedText>
       </ThemedView>
       <ThemedView style={styles.stepContainer}>

--- a/TangThuLauNative/app/(tabs)/search.tsx
+++ b/TangThuLauNative/app/(tabs)/search.tsx
@@ -8,7 +8,7 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 
-export default function TabTwoScreen() {
+export default function SearchScreen() {
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
@@ -21,14 +21,14 @@ export default function TabTwoScreen() {
         />
       }>
       <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Explore</ThemedText>
+        <ThemedText type="title">Search</ThemedText>
       </ThemedView>
       <ThemedText>This app includes example code to help you get started.</ThemedText>
       <Collapsible title="File-based routing">
         <ThemedText>
           This app has two screens:{' '}
           <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/explore.tsx</ThemedText>
+          <ThemedText type="defaultSemiBold">app/(tabs)/search.tsx</ThemedText>
         </ThemedText>
         <ThemedText>
           The layout file in <ThemedText type="defaultSemiBold">app/(tabs)/_layout.tsx</ThemedText>{' '}

--- a/TangThuLauNative/app/(tabs)/settings.tsx
+++ b/TangThuLauNative/app/(tabs)/settings.tsx
@@ -5,7 +5,7 @@ import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedView } from '@/components/ThemedView';
 import GoogleLogin from "@/components/GoogleLogin";
 
-export default function ProfileScreen() {
+export default function SettingsScreen() {
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}

--- a/TangThuLauNative/components/ui/IconSymbol.tsx
+++ b/TangThuLauNative/components/ui/IconSymbol.tsx
@@ -18,6 +18,8 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'magnifyingglass': 'search',
+  'gearshape.fill': 'settings',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- rename Explore tab to Search and Profile tab to Settings
- update bottom tab navigator to use Home, Search and Settings
- adjust example copy for the Search tab
- map new icons for Search and Settings

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f670ef588328a6c47e2af22bf0e5