### PR TITLE
Add simple mobile home page

### DIFF
--- a/TangThuLauNative/components/StoryItem.tsx
+++ b/TangThuLauNative/components/StoryItem.tsx
@@ -1,0 +1,34 @@
+import { Image } from 'expo-image';
+import { View, Text, StyleSheet, ViewStyle } from 'react-native';
+import { Story } from '@/types/Story';
+
+export default function StoryItem({ story, style }: { story: Story; style?: ViewStyle }) {
+  return (
+    <View style={[styles.container, style]}>
+      <Image source={{ uri: story.cover }} style={styles.cover} contentFit="cover" />
+      <Text style={styles.title} numberOfLines={1}>{story.title}</Text>
+      <Text style={styles.author} numberOfLines={1}>{story.author?.name}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: 120,
+    marginRight: 12,
+  },
+  cover: {
+    width: '100%',
+    height: 160,
+    borderRadius: 8,
+    backgroundColor: '#ccc',
+  },
+  title: {
+    fontWeight: 'bold',
+    marginTop: 4,
+  },
+  author: {
+    fontSize: 12,
+    color: '#666',
+  },
+});

--- a/TangThuLauNative/constants/Api.ts
+++ b/TangThuLauNative/constants/Api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = 'http://localhost:5000';

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -5,10 +5,11 @@
     "profile": "Profile"
   },
   "home": {
-    "welcome": "Welcome!",
-    "step1Title": "Step 1: Try it",
-    "step2Title": "Step 2: Search",
-    "step3Title": "Step 3: Get a fresh start"
+    "top_recommend_title": "Top Recommended Stories",
+    "most_recommended": "Most Recommended Stories",
+    "most_viewed": "Most Viewed Stories",
+    "most_liked": "Most Liked Stories",
+    "longest": "Longest Stories"
   },
   "search": {
     "title": "Search"

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -5,10 +5,11 @@
     "profile": "Hồ sơ"
   },
   "home": {
-    "welcome": "Chào mừng!",
-    "step1Title": "Bước 1: Thử nó",
-    "step2Title": "Bước 2: Tìm kiếm",
-    "step3Title": "Bước 3: Bắt đầu mới"
+    "top_recommend_title": "Top Truyện Đề Cử",
+    "most_recommended": "Truyện Đề Cử Nhiều",
+    "most_viewed": "Truyện Đọc Nhiều",
+    "most_liked": "Truyện Yêu Thích Nhiều",
+    "longest": "Truyện Dài Nhất"
   },
   "search": {
     "title": "Tìm kiếm"

--- a/TangThuLauNative/types/Story.ts
+++ b/TangThuLauNative/types/Story.ts
@@ -1,0 +1,17 @@
+export interface Story {
+  _id: string;
+  title: string;
+  slug: string;
+  description: string;
+  intro: string;
+  cover: string;
+  totalChapters: number;
+  views: number;
+  likes: number;
+  votes: number;
+  recommends: number;
+  categories: { name: string; _id: string; slug: string }[];
+  tags: { name: string; _id: string; slug: string }[];
+  author: { name: string; _id: string; slug: string };
+  source: { name: string; _id: string; url: string };
+}


### PR DESCRIPTION
## Summary
- create API constant
- add Story interface and item component
- show stories from API on mobile home screen
- update English and Vietnamese translations for new home page text

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868002c24148328b12f3d5731af4c8d