### PR TITLE
Update bottom tabs

### DIFF
--- a/TangThuLauNative/app/(tabs)/_layout.tsx
+++ b/TangThuLauNative/app/(tabs)/_layout.tsx
@@ -29,6 +29,13 @@ export default function TabLayout() {
         }),
       }}>
       <Tabs.Screen
+        name="search"
+        options={{
+          title: t('tabs.search'),
+          tabBarIcon: ({ color }) => <IconSymbol size={18} name="book.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
         name="index"
         options={{
           title: t('tabs.home'),
@@ -36,17 +43,10 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="search"
-        options={{
-          title: t('tabs.search'),
-          tabBarIcon: ({ color }) => <IconSymbol size={18} name="magnifyingglass" color={color} />,
-        }}
-      />
-      <Tabs.Screen
         name="profile"
         options={{
           title: t('tabs.profile'),
-          tabBarIcon: ({ color }) => <IconSymbol size={18} name="person.crop.circle" color={color} />,
+          tabBarIcon: ({ color }) => <IconSymbol size={18} name="gearshape.fill" color={color} />,
         }}
       />
     </Tabs>

--- a/TangThuLauNative/components/ui/IconSymbol.tsx
+++ b/TangThuLauNative/components/ui/IconSymbol.tsx
@@ -20,6 +20,8 @@ const MAPPING = {
   'chevron.right': 'chevron-right',
   'magnifyingglass': 'search',
   'gearshape.fill': 'settings',
+  'book.fill': 'book',
+  'person.crop.circle': 'account-circle',
 } as IconMapping;
 
 /**

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -1,8 +1,8 @@
 {
   "tabs": {
-    "home": "Home",
-    "search": "Search",
-    "profile": "Profile"
+    "home": "Library",
+    "search": "Bookshelf",
+    "profile": "Account"
   },
   "home": {
     "top_recommend_title": "Top Recommended Stories",
@@ -12,7 +12,7 @@
     "longest": "Longest Stories"
   },
   "search": {
-    "title": "Search"
+    "title": "Bookshelf"
   },
   "profile": {
     "switchLanguage": "Switch Language"

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -1,8 +1,8 @@
 {
   "tabs": {
-    "home": "Trang chủ",
-    "search": "Tìm kiếm",
-    "profile": "Hồ sơ"
+    "home": "Thư viện",
+    "search": "Tủ sách",
+    "profile": "Tài khoản"
   },
   "home": {
     "top_recommend_title": "Top Truyện Đề Cử",
@@ -12,7 +12,7 @@
     "longest": "Truyện Dài Nhất"
   },
   "search": {
-    "title": "Tìm kiếm"
+    "title": "Tủ sách"
   },
   "profile": {
     "switchLanguage": "Chuyển ngôn ngữ"


### PR DESCRIPTION
## Summary
- rename bottom tabs to "Tủ sách", "Thư viện", "Tài khoản"
- reorder tab layout so "Thư viện" (home) is in the middle
- map new icons for bookshelf and settings
- update English and Vietnamese translations

## Testing
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68680279ad1c8328a143c8b612c19f92