### PR TITLE
Add reading history sync feature

### DIFF
--- a/TangThuLauNative/app/(tabs)/search.tsx
+++ b/TangThuLauNative/app/(tabs)/search.tsx
@@ -1,112 +1,79 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
-
-import { Collapsible } from '@/components/Collapsible';
-import { ExternalLink } from '@/components/ExternalLink';
+import { FlatList, StyleSheet } from 'react-native';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useReadingHistory } from '@/contexts/ReadingHistoryContext';
+import { useEffect } from 'react';
+import { Image } from 'expo-image';
 
-export default function SearchScreen() {
+export default function BookshelfScreen() {
   const { t } = useTranslation();
+  const { history, syncWithServer, loggedIn } = useReadingHistory();
+
+  useEffect(() => {
+    syncWithServer();
+  }, [loggedIn]);
+
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
-      headerImage={
-        <IconSymbol
-          size={310}
-          color="#808080"
-          name="chevron.left.forwardslash.chevron.right"
-          style={styles.headerImage}
-        />
-      }>
+      headerImage={<Image source={require('@/assets/images/react-logo.png')} style={styles.headerImage} />}
+    >
       <ThemedView style={styles.titleContainer}>
         <ThemedText type="title">{t('search.title')}</ThemedText>
       </ThemedView>
-      <ThemedText>This app includes example code to help you get started.</ThemedText>
-      <Collapsible title="File-based routing">
-        <ThemedText>
-          This app has two screens:{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/search.tsx</ThemedText>
-        </ThemedText>
-        <ThemedText>
-          The layout file in <ThemedText type="defaultSemiBold">app/(tabs)/_layout.tsx</ThemedText>{' '}
-          sets up the tab navigator.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/router/introduction">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Android, iOS, and web support">
-        <ThemedText>
-          You can open this project on Android, iOS, and the web. To open the web version, press{' '}
-          <ThemedText type="defaultSemiBold">w</ThemedText> in the terminal running this project.
-        </ThemedText>
-      </Collapsible>
-      <Collapsible title="Images">
-        <ThemedText>
-          For static images, you can use the <ThemedText type="defaultSemiBold">@2x</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">@3x</ThemedText> suffixes to provide files for
-          different screen densities
-        </ThemedText>
-        <Image source={require('@/assets/images/react-logo.png')} style={{ alignSelf: 'center' }} />
-        <ExternalLink href="https://reactnative.dev/docs/images">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Custom fonts">
-        <ThemedText>
-          Open <ThemedText type="defaultSemiBold">app/_layout.tsx</ThemedText> to see how to load{' '}
-          <ThemedText style={{ fontFamily: 'SpaceMono' }}>
-            custom fonts such as this one.
-          </ThemedText>
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/versions/latest/sdk/font">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Light and dark mode components">
-        <ThemedText>
-          This template has light and dark mode support. The{' '}
-          <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText> hook lets you inspect
-          what the user&apos;s current color scheme is, and so you can adjust UI colors accordingly.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Animations">
-        <ThemedText>
-          This template includes an example of an animated component. The{' '}
-          <ThemedText type="defaultSemiBold">components/HelloWave.tsx</ThemedText> component uses
-          the powerful <ThemedText type="defaultSemiBold">react-native-reanimated</ThemedText>{' '}
-          library to create a waving hand animation.
-        </ThemedText>
-        {Platform.select({
-          ios: (
-            <ThemedText>
-              The <ThemedText type="defaultSemiBold">components/ParallaxScrollView.tsx</ThemedText>{' '}
-              component provides a parallax effect for the header image.
-            </ThemedText>
-          ),
-        })}
-      </Collapsible>
+      {history.length === 0 ? (
+        <ThemedText>{t('search.no_history') || 'No reading history'}</ThemedText>
+      ) : (
+        <FlatList
+          data={history}
+          keyExtractor={(item) => item.storySlug}
+          renderItem={({ item }) => (
+            <ThemedView style={styles.item}>
+              <Image source={{ uri: item.cover }} style={styles.cover} contentFit="cover" />
+              <ThemedView style={{ flex: 1 }}>
+                <ThemedText style={styles.title}>{item.storyTitle}</ThemedText>
+                <ThemedText style={styles.chapter}>{`Chapter ${item.chapter}`}</ThemedText>
+              </ThemedView>
+            </ThemedView>
+          )}
+        />
+      )}
     </ParallaxScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   headerImage: {
-    color: '#808080',
-    bottom: -90,
-    left: -35,
+    height: 120,
+    width: 200,
+    bottom: -20,
+    left: -20,
     position: 'absolute',
   },
   titleContainer: {
     flexDirection: 'row',
     gap: 8,
+    marginBottom: 16,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  cover: {
+    width: 60,
+    height: 80,
+    borderRadius: 4,
+    marginRight: 12,
+    backgroundColor: '#ccc',
+  },
+  title: {
+    fontWeight: 'bold',
+  },
+  chapter: {
+    fontSize: 12,
+    color: '#666',
   },
 });

--- a/TangThuLauNative/app/_layout.tsx
+++ b/TangThuLauNative/app/_layout.tsx
@@ -6,6 +6,7 @@ import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { LanguageProvider } from '@/contexts/LanguageContext';
+import { ReadingHistoryProvider } from '@/contexts/ReadingHistoryContext';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -20,13 +21,15 @@ export default function RootLayout() {
 
   return (
     <LanguageProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
+      <ReadingHistoryProvider>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </ReadingHistoryProvider>
     </LanguageProvider>
   );
 }

--- a/TangThuLauNative/components/GoogleLogin.tsx
+++ b/TangThuLauNative/components/GoogleLogin.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Alert, View, Text } from 'react-native';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useReadingHistory } from '@/contexts/ReadingHistoryContext';
 
 // Cấu hình Google Sign-In
 GoogleSignin.configure({
@@ -13,12 +14,15 @@ GoogleSignin.configure({
 
 export default function GoogleLogin() {
   const { t } = useTranslation();
+  const { setLoggedIn, syncWithServer } = useReadingHistory();
   const signIn = async () => {
     try {
       await GoogleSignin.hasPlayServices();
       const userInfo: any = await GoogleSignin.signIn();
       console.log('✅ Đăng nhập thành công:', userInfo);
       Alert.alert('Xin chào!', userInfo.user.name);
+      setLoggedIn(true);
+      syncWithServer();
     } catch (error: any) {
       console.error('❌ Lỗi đăng nhập:', error);
       Alert.alert('Lỗi', error.message);

--- a/TangThuLauNative/contexts/ReadingHistoryContext.tsx
+++ b/TangThuLauNative/contexts/ReadingHistoryContext.tsx
@@ -1,0 +1,83 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { API_BASE_URL } from '@/constants/Api';
+
+export interface HistoryItem {
+  storySlug: string;
+  storyTitle: string;
+  cover: string;
+  chapter: number;
+}
+
+interface ContextValue {
+  history: HistoryItem[];
+  addHistory: (item: HistoryItem) => Promise<void>;
+  syncWithServer: () => Promise<void>;
+  setHistory: React.Dispatch<React.SetStateAction<HistoryItem[]>>;
+  loggedIn: boolean;
+  setLoggedIn: (b: boolean) => void;
+}
+
+const STORAGE_KEY = 'reading-history';
+
+const ReadingHistoryContext = createContext<ContextValue>({
+  history: [],
+  addHistory: async () => {},
+  syncWithServer: async () => {},
+  setHistory: () => {},
+  loggedIn: false,
+  setLoggedIn: () => {},
+});
+
+export const ReadingHistoryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then((val) => {
+      if (val) setHistory(JSON.parse(val));
+    });
+  }, []);
+
+  const save = async (data: HistoryItem[]) => {
+    setHistory(data);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  };
+
+  const addHistory = async (item: HistoryItem) => {
+    const existing = history.filter((h) => h.storySlug !== item.storySlug);
+    await save([{ ...item, chapter: item.chapter }, ...existing]);
+  };
+
+  const syncWithServer = async () => {
+    if (!loggedIn) return;
+    try {
+      await fetch(`${API_BASE_URL}/reading-history/sync`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: history }),
+        credentials: 'include',
+      });
+      const res = await fetch(`${API_BASE_URL}/reading-history`, { credentials: 'include' });
+      const data = await res.json();
+      if (Array.isArray(data)) {
+        await save(data.map((d: any) => ({
+          storySlug: d.story.slug,
+          storyTitle: d.story.title,
+          cover: d.story.cover,
+          chapter: d.chapter,
+        })));
+      }
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
+  return (
+    <ReadingHistoryContext.Provider value={{ history, addHistory, syncWithServer, setHistory, loggedIn, setLoggedIn }}>
+      {children}
+    </ReadingHistoryContext.Provider>
+  );
+};
+
+export const useReadingHistory = () => useContext(ReadingHistoryContext);

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -12,7 +12,8 @@
     "longest": "Longest Stories"
   },
   "search": {
-    "title": "Bookshelf"
+    "title": "Bookshelf",
+    "no_history": "No reading history"
   },
   "profile": {
     "switchLanguage": "Switch Language"

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -12,7 +12,8 @@
     "longest": "Truyện Dài Nhất"
   },
   "search": {
-    "title": "Tủ sách"
+    "title": "Tủ sách",
+    "no_history": "Chưa có lịch sử đọc"
   },
   "profile": {
     "switchLanguage": "Chuyển ngôn ngữ"

--- a/TangThuLauNative/package.json
+++ b/TangThuLauNative/package.json
@@ -43,7 +43,8 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "expo-dev-client": "~5.2.4",
-    "i18n-js": "^3.9.2"
+    "i18n-js": "^3.9.2",
+    "@react-native-async-storage/async-storage": "^1.18.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -36,6 +36,7 @@ import { BlogModule } from './modules/blog/blog.module';
 import { RolesGuard } from './modules/auth/guards/role.guard';
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
 import { DB_STORIES_NAMES, DBNames, getDBURIs } from "./utils/database";
+import { ReadingHistoryModule } from './modules/reading-history/reading-history.module';
 
 @Module({
   imports: [
@@ -87,6 +88,7 @@ import { DB_STORIES_NAMES, DBNames, getDBURIs } from "./utils/database";
     TagModule,
     AuthModule,
     SourceModule,
+    ReadingHistoryModule,
     BlogModule,
   ],
   providers: [

--- a/backend/src/modules/reading-history/dto/sync-reading-history.dto.ts
+++ b/backend/src/modules/reading-history/dto/sync-reading-history.dto.ts
@@ -1,0 +1,3 @@
+export class SyncReadingHistoryDto {
+  items: { storySlug: string; chapter: number }[];
+}

--- a/backend/src/modules/reading-history/reading-history.controller.ts
+++ b/backend/src/modules/reading-history/reading-history.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { ReadingHistoryService } from './reading-history.service';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RoleSlug } from '@/constants/role.enum';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { SyncReadingHistoryDto } from './dto/sync-reading-history.dto';
+
+@Controller('reading-history')
+export class ReadingHistoryController {
+  constructor(private readonly service: ReadingHistoryService) {}
+
+  @Roles(RoleSlug.READER)
+  @Get()
+  async getHistory(@CurrentUser('userId') userId: string) {
+    return this.service.getHistory(userId);
+  }
+
+  @Roles(RoleSlug.READER)
+  @Post('sync')
+  async syncHistory(
+    @CurrentUser('userId') userId: string,
+    @Body() dto: SyncReadingHistoryDto
+  ) {
+    await this.service.syncHistory(userId, dto.items || []);
+    return this.service.getHistory(userId);
+  }
+}

--- a/backend/src/modules/reading-history/reading-history.module.ts
+++ b/backend/src/modules/reading-history/reading-history.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ReadingHistory, ReadingHistorySchema } from '@/schemas/readingHistory.schema';
+import { Story, StorySchema } from '@/schemas/story.schema';
+import { ReadingHistoryService } from './reading-history.service';
+import { ReadingHistoryController } from './reading-history.controller';
+import { DBNames } from '@/utils/database';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: ReadingHistory.name, schema: ReadingHistorySchema }], DBNames.ums),
+    MongooseModule.forFeature([{ name: Story.name, schema: StorySchema }], DBNames.story1),
+    MongooseModule.forFeature([{ name: Story.name, schema: StorySchema }], DBNames.story2),
+    MongooseModule.forFeature([{ name: Story.name, schema: StorySchema }], DBNames.story3),
+    MongooseModule.forFeature([{ name: Story.name, schema: StorySchema }], DBNames.story4),
+    MongooseModule.forFeature([{ name: Story.name, schema: StorySchema }], DBNames.story5),
+  ],
+  providers: [ReadingHistoryService],
+  controllers: [ReadingHistoryController],
+})
+export class ReadingHistoryModule {}

--- a/backend/src/modules/reading-history/reading-history.service.ts
+++ b/backend/src/modules/reading-history/reading-history.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ReadingHistory } from '@/schemas/readingHistory.schema';
+import { Story } from '@/schemas/story.schema';
+import { DBNames } from '@/utils/database';
+
+@Injectable()
+export class ReadingHistoryService {
+  constructor(
+    @InjectModel(ReadingHistory.name, DBNames.ums)
+    private historyModel: Model<ReadingHistory>,
+    @InjectModel(Story.name, DBNames.story1)
+    private story1Model: Model<Story>,
+    @InjectModel(Story.name, DBNames.story2)
+    private story2Model: Model<Story>,
+    @InjectModel(Story.name, DBNames.story3)
+    private story3Model: Model<Story>,
+    @InjectModel(Story.name, DBNames.story4)
+    private story4Model: Model<Story>,
+    @InjectModel(Story.name, DBNames.story5)
+    private story5Model: Model<Story>,
+  ) {}
+
+  private getStoryModelList() {
+    return [
+      this.story1Model,
+      this.story2Model,
+      this.story3Model,
+      this.story4Model,
+      this.story5Model,
+    ];
+  }
+
+  private async findStoryBySlug(slug: string) {
+    for (const model of this.getStoryModelList()) {
+      const story = await model.findOne({ slug }).select('_id');
+      if (story) return story;
+    }
+    return null;
+  }
+
+  async getHistory(userId: string) {
+    return this.historyModel
+      .find({ user: userId })
+      .populate('story', 'title slug cover')
+      .sort({ updatedAt: -1 });
+  }
+
+  async syncHistory(userId: string, items: { storySlug: string; chapter: number }[]) {
+    for (const item of items) {
+      const story = await this.findStoryBySlug(item.storySlug);
+      if (!story) continue;
+      await this.historyModel.updateOne(
+        { user: userId, story: story._id },
+        { chapter: item.chapter, updatedAt: new Date() },
+        { upsert: true }
+      );
+    }
+  }
+}

--- a/backend/src/schemas/readingHistory.schema.ts
+++ b/backend/src/schemas/readingHistory.schema.ts
@@ -1,0 +1,16 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class ReadingHistory extends Document {
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  user: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'Story', required: true })
+  story: Types.ObjectId;
+
+  @Prop({ required: true })
+  chapter: number;
+}
+
+export const ReadingHistorySchema = SchemaFactory.createForClass(ReadingHistory);


### PR DESCRIPTION
## Summary
- add reading history context in the mobile app
- display reading history in the bookshelf tab
- sync device history with server on login
- register new backend module `reading-history`
- include `reading-history` APIs and schema
- wrap native app with new provider

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in backend *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686807d5fef48328b72b2e72e97a863d