### PR TITLE
Remove new option from update queries

### DIFF
--- a/backend/src/modules/chapter/chapter.service.ts
+++ b/backend/src/modules/chapter/chapter.service.ts
@@ -215,7 +215,7 @@ export class ChapterService {
             await chapterContentModel.findOneAndUpdate({ chapter: chapterSlug }, {
               content
             }, {
-              new: true
+              upsert: true
             });
           }
           break;

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -72,7 +72,7 @@ export class UserService {
       email: dto.email,
       name: dto.name,
       role: dto.role,
-    }, { new: true });
+    }, { upsert: true });
   }
 
   async delete(id: string) {


### PR DESCRIPTION
## Summary
- update query options that used `{ new: true }` to `{ upsert: true }`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868173da0688328a05799157396b71a