### PR TITLE
Add search page with filters in TangThuLauNative

### DIFF
--- a/TangThuLauNative/app/(tabs)/search.tsx
+++ b/TangThuLauNative/app/(tabs)/search.tsx
@@ -1,45 +1,166 @@
-import { FlatList, StyleSheet } from 'react-native';
+import { useState, useEffect } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Modal,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+} from 'react-native';
+import { Image } from 'expo-image';
+
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { useTranslation } from '@/hooks/useTranslation';
-import { useReadingHistory } from '@/contexts/ReadingHistoryContext';
-import { useEffect } from 'react';
-import { Image } from 'expo-image';
+import { API_BASE_URL } from '@/constants/Api';
+import StoryItem from '@/components/StoryItem';
+import { Story } from '@/types/Story';
 
-export default function BookshelfScreen() {
+interface Category { _id: string; name: string }
+interface Author { _id: string; name: string }
+
+export default function SearchScreen() {
   const { t } = useTranslation();
-  const { history, syncWithServer, loggedIn } = useReadingHistory();
+
+  const [keyword, setKeyword] = useState('');
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [authors, setAuthors] = useState<Author[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
+  const [selectedAuthor, setSelectedAuthor] = useState<Author | null>(null);
+  const [categoryModal, setCategoryModal] = useState(false);
+  const [authorModal, setAuthorModal] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<Story[]>([]);
 
   useEffect(() => {
-    syncWithServer();
-  }, [loggedIn]);
+    fetch(`${API_BASE_URL}/categories`)
+      .then((r) => r.json())
+      .then((d) => setCategories(d || []))
+      .catch(console.warn);
+
+    fetch(`${API_BASE_URL}/authors`)
+      .then((r) => r.json())
+      .then((d) => setAuthors(d.data || []))
+      .catch(console.warn);
+  }, []);
+
+  const search = async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams();
+      if (keyword) params.append('keyword', keyword);
+      if (selectedCategory) params.append('categories', selectedCategory.name);
+      if (selectedAuthor) params.append('author', selectedAuthor._id);
+      const res = await fetch(`${API_BASE_URL}/stories?${params.toString()}`);
+      const data = await res.json();
+      setResults(data.data || []);
+    } catch (e) {
+      console.warn(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderStory = ({ item }: { item: Story }) => (
+    <StoryItem story={item} style={{ marginBottom: 12, width: '100%' }} />
+  );
 
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
-      headerImage={<Image source={require('@/assets/images/react-logo.png')} style={styles.headerImage} />}
-    >
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">{t('search.title')}</ThemedText>
+      headerImage={
+        <Image
+          source={require('@/assets/images/react-logo.png')}
+          style={styles.headerImage}
+        />
+      }>
+      <ThemedView style={styles.form}>
+        <TextInput
+          placeholder={t('home.search_placeholder')}
+          value={keyword}
+          onChangeText={setKeyword}
+          style={styles.input}
+        />
+        <TouchableOpacity
+          style={styles.select}
+          onPress={() => setCategoryModal(true)}>
+          <ThemedText>
+            {selectedCategory ? selectedCategory.name : t('search.category')}
+          </ThemedText>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.select}
+          onPress={() => setAuthorModal(true)}>
+          <ThemedText>
+            {selectedAuthor ? selectedAuthor.name : t('search.author')}
+          </ThemedText>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button} onPress={search}>
+          <ThemedText style={styles.buttonText}>{t('search.search')}</ThemedText>
+        </TouchableOpacity>
       </ThemedView>
-      {history.length === 0 ? (
-        <ThemedText>{t('search.no_history') || 'No reading history'}</ThemedText>
+      {loading ? (
+        <ActivityIndicator />
+      ) : results.length === 0 ? (
+        <ThemedText>{t('search.no_result')}</ThemedText>
       ) : (
         <FlatList
-          data={history}
-          keyExtractor={(item) => item.storySlug}
-          renderItem={({ item }) => (
-            <ThemedView style={styles.item}>
-              <Image source={{ uri: item.cover }} style={styles.cover} contentFit="cover" />
-              <ThemedView style={{ flex: 1 }}>
-                <ThemedText style={styles.title}>{item.storyTitle}</ThemedText>
-                <ThemedText style={styles.chapter}>{`Chapter ${item.chapter}`}</ThemedText>
-              </ThemedView>
-            </ThemedView>
-          )}
+          data={results}
+          keyExtractor={(item) => item._id}
+          renderItem={renderStory}
         />
       )}
+      <Modal visible={categoryModal} transparent animationType="slide">
+        <ThemedView style={styles.modalOverlay}>
+          <ThemedView style={styles.modalContent}>
+            <FlatList
+              data={categories}
+              keyExtractor={(item) => item._id}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={styles.modalItem}
+                  onPress={() => {
+                    setSelectedCategory(item);
+                    setCategoryModal(false);
+                  }}>
+                  <ThemedText>{item.name}</ThemedText>
+                </TouchableOpacity>
+              )}
+            />
+            <TouchableOpacity
+              style={[styles.button, { marginTop: 8 }]}
+              onPress={() => setCategoryModal(false)}>
+              <ThemedText style={styles.buttonText}>{t('search.cancel')}</ThemedText>
+            </TouchableOpacity>
+          </ThemedView>
+        </ThemedView>
+      </Modal>
+      <Modal visible={authorModal} transparent animationType="slide">
+        <ThemedView style={styles.modalOverlay}>
+          <ThemedView style={styles.modalContent}>
+            <FlatList
+              data={authors}
+              keyExtractor={(item) => item._id}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={styles.modalItem}
+                  onPress={() => {
+                    setSelectedAuthor(item);
+                    setAuthorModal(false);
+                  }}>
+                  <ThemedText>{item.name}</ThemedText>
+                </TouchableOpacity>
+              )}
+            />
+            <TouchableOpacity
+              style={[styles.button, { marginTop: 8 }]}
+              onPress={() => setAuthorModal(false)}>
+              <ThemedText style={styles.buttonText}>{t('search.cancel')}</ThemedText>
+            </TouchableOpacity>
+          </ThemedView>
+        </ThemedView>
+      </Modal>
     </ParallaxScrollView>
   );
 }
@@ -52,28 +173,49 @@ const styles = StyleSheet.create({
     left: -20,
     position: 'absolute',
   },
-  titleContainer: {
-    flexDirection: 'row',
+  form: {
     gap: 8,
     marginBottom: 16,
   },
-  item: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 12,
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
   },
-  cover: {
-    width: 60,
-    height: 80,
-    borderRadius: 4,
-    marginRight: 12,
-    backgroundColor: '#ccc',
+  select: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
   },
-  title: {
+  button: {
+    backgroundColor: '#0a7ea4',
+    borderRadius: 8,
+    paddingVertical: 10,
+  },
+  buttonText: {
+    color: '#fff',
+    textAlign: 'center',
     fontWeight: 'bold',
   },
-  chapter: {
-    fontSize: 12,
-    color: '#666',
+  modalOverlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  modalContent: {
+    width: '80%',
+    maxHeight: '70%',
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 16,
+  },
+  modalItem: {
+    paddingVertical: 8,
   },
 });
+

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -1,7 +1,7 @@
 {
   "tabs": {
     "home": "Library",
-    "search": "Bookshelf",
+    "search": "Search",
     "profile": "Account"
   },
   "home": {
@@ -13,8 +13,13 @@
     "search_placeholder": "Search stories..."
   },
   "search": {
-    "title": "Bookshelf",
-    "no_history": "No reading history"
+    "title": "Search",
+    "no_history": "No reading history",
+    "no_result": "No results found",
+    "category": "Category",
+    "author": "Author",
+    "search": "Search",
+    "cancel": "Cancel"
   },
   "profile": {
     "switchLanguage": "Switch Language"

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -1,7 +1,7 @@
 {
   "tabs": {
     "home": "Thư viện",
-    "search": "Tủ sách",
+    "search": "Tìm kiếm",
     "profile": "Tài khoản"
   },
   "home": {
@@ -13,8 +13,13 @@
     "search_placeholder": "Tìm kiếm truyện..."
   },
   "search": {
-    "title": "Tủ sách",
-    "no_history": "Chưa có lịch sử đọc"
+    "title": "Tìm kiếm",
+    "no_history": "Chưa có lịch sử đọc",
+    "no_result": "Không có kết quả",
+    "category": "Thể loại",
+    "author": "Tác giả",
+    "search": "Tìm kiếm",
+    "cancel": "Hủy"
   },
   "profile": {
     "switchLanguage": "Chuyển ngôn ngữ"


### PR DESCRIPTION
## Summary
- add search screen for expo native app
- support searching stories by keyword, category and author
- update translations for new search feature

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681d96a2c483288dbe910924534fa1