### PR TITLE
Fix AsyncStorage load and fragment style warning

### DIFF
--- a/TangThuLauNative/contexts/ReadingHistoryContext.tsx
+++ b/TangThuLauNative/contexts/ReadingHistoryContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import AsyncStorage from '@/utils/asyncStorage';
 import { API_BASE_URL } from '@/constants/Api';
 
 export interface HistoryItem {

--- a/TangThuLauNative/utils/asyncStorage.ts
+++ b/TangThuLauNative/utils/asyncStorage.ts
@@ -1,0 +1,34 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+// Fallback for environments where the native module is unavailable (e.g. web)
+let storage: typeof AsyncStorage | {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+} | null = AsyncStorage
+
+if (!storage || typeof storage.getItem !== 'function') {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      storage = {
+        async getItem(key: string) {
+          return localStorage.getItem(key)
+        },
+        async setItem(key: string, value: string) {
+          localStorage.setItem(key, value)
+        },
+      }
+    }
+  } catch {
+    const memory = new Map<string, string>()
+    storage = {
+      async getItem(key: string) {
+        return memory.get(key) ?? null
+      },
+      async setItem(key: string, value: string) {
+        memory.set(key, value)
+      },
+    }
+  }
+}
+
+export default storage as typeof AsyncStorage

--- a/admin-frontend/src/components/tiptap-ui-primitive/dropdown-menu/dropdown-menu.tsx
+++ b/admin-frontend/src/components/tiptap-ui-primitive/dropdown-menu/dropdown-menu.tsx
@@ -169,17 +169,20 @@ export const DropdownMenuTrigger = React.forwardRef<
       "data-state": context.open ? "open" : "closed",
     }
 
-    return React.cloneElement(
-      children,
-      context.getReferenceProps({
-        ref,
-        ...props,
-        ...(typeof children.props === "object" ? children.props : {}),
-        "aria-expanded": context.open,
-        "aria-haspopup": "menu" as const,
-        ...dataAttributes,
-      })
-    )
+    const clonedProps = context.getReferenceProps({
+      ref,
+      ...props,
+      ...(typeof children.props === "object" ? children.props : {}),
+      "aria-expanded": context.open,
+      "aria-haspopup": "menu" as const,
+      ...dataAttributes,
+    })
+
+    if (children.type === React.Fragment) {
+      return <span {...clonedProps}>{children.props.children}</span>
+    }
+
+    return React.cloneElement(children, clonedProps)
   }
 
   return (
@@ -336,6 +339,14 @@ export const DropdownMenuItem = React.forwardRef<
           handleSelect(event as unknown as React.MouseEvent<HTMLDivElement>)
           childProps.onClick?.(event)
         },
+      }
+
+      if (children.type === React.Fragment) {
+        return (
+          <span {...mergedProps} {...eventHandlers}>
+            {children.props.children}
+          </span>
+        )
       }
 
       return React.cloneElement(children, {

--- a/admin-frontend/src/components/tiptap-ui-primitive/popover/popover.tsx
+++ b/admin-frontend/src/components/tiptap-ui-primitive/popover/popover.tsx
@@ -173,15 +173,19 @@ const PopoverTrigger = React.forwardRef<HTMLElement, TriggerElementProps>(
     const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef])
 
     if (asChild && React.isValidElement(children)) {
-      return React.cloneElement(
-        children,
-        context.getReferenceProps({
-          ref,
-          ...props,
-          ...(children.props as any),
-          "data-state": context.open ? "open" : "closed",
-        })
-      )
+      const clonedProps = context.getReferenceProps({
+        ref,
+        ...props,
+        ...(children.props as any),
+        "data-state": context.open ? "open" : "closed",
+      })
+
+      // Wrap React.Fragment children to avoid passing invalid props
+      if (children.type === React.Fragment) {
+        return <span {...clonedProps}>{children.props.children}</span>
+      }
+
+      return React.cloneElement(children, clonedProps)
     }
 
     return (

--- a/admin-frontend/src/components/tiptap-ui-primitive/tooltip/tooltip.tsx
+++ b/admin-frontend/src/components/tiptap-ui-primitive/tooltip/tooltip.tsx
@@ -171,6 +171,17 @@ export const TooltipTrigger = React.forwardRef<
       "data-tooltip-state": context.open ? "open" : "closed",
     }
 
+    // Avoid passing props to React.Fragment which only accepts key and children
+    if (children.type === React.Fragment) {
+      return (
+        <span
+          {...context.getReferenceProps({ ref, ...props, ...dataAttributes })}
+        >
+          {children.props.children}
+        </span>
+      )
+    }
+
     return React.cloneElement(
       children,
       context.getReferenceProps({


### PR DESCRIPTION
## Summary
- add fallback AsyncStorage implementation for non-native envs
- use fallback in ReadingHistoryContext
- prevent passing props to React.Fragment in tooltip, popover and dropdown menu primitives

## Testing
- `npm run lint` (fails: cannot find package '@eslint/js')
- `npm run lint` in TangThuLauNative (fails: expo not found)
- `npm run lint` in web-reader (fails: cannot find package 'eslint')

------
https://chatgpt.com/codex/tasks/task_e_6868229c11808328b7d9c988a1490cab