### PR TITLE
Fix missing Expo CLI version source

### DIFF
--- a/TangThuLauNative/eas.json
+++ b/TangThuLauNative/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 3.14.0"
+    "version": ">= 3.14.0",
+    "appVersionSource": "local"
   },
   "build": {
     "preview": {


### PR DESCRIPTION
## Summary
- set the Expo CLI `appVersionSource` to stop future warnings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68686dd0f4dc8328bd36d2f1fedc0334