### PR TITLE
Fix Google login idToken retrieval

### DIFF
--- a/TangThuLauNative/components/GoogleLogin.tsx
+++ b/TangThuLauNative/components/GoogleLogin.tsx
@@ -21,8 +21,11 @@ export default function GoogleLogin() {
     try {
       await GoogleSignin.hasPlayServices();
       const userInfo: any = await GoogleSignin.signIn();
-      console.log("userInfo", userInfo)
-      const idToken = userInfo.idToken;
+      console.log('userInfo', userInfo);
+
+      // In some environments idToken may be undefined after sign in.
+      // Fetch tokens explicitly to ensure we get a valid idToken
+      const { idToken } = await GoogleSignin.getTokens();
 
       if (!idToken) throw new Error('No idToken received');
 


### PR DESCRIPTION
## Summary
- ensure Google signin fetches `idToken` using `getTokens`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868a1474fd48328a81b6347cdab28aa