### PR TITLE
Add logout button for mobile app

### DIFF
--- a/TangThuLauNative/app/(tabs)/profile.tsx
+++ b/TangThuLauNative/app/(tabs)/profile.tsx
@@ -8,10 +8,26 @@ import { Button } from 'react-native';
 import { useContext } from 'react';
 import { LanguageContext } from '@/contexts/LanguageContext';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useReadingHistory } from '@/contexts/ReadingHistoryContext';
+import { API_BASE_URL } from '@/constants/Api';
 
 export default function ProfileScreen() {
   const { toggleLanguage } = useContext(LanguageContext);
   const { t } = useTranslation();
+  const { loggedIn, setLoggedIn } = useReadingHistory();
+
+  const logout = async () => {
+    try {
+      await fetch(`${API_BASE_URL}/auth/logout`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+    } catch (e) {
+      console.warn(e);
+    } finally {
+      setLoggedIn(false);
+    }
+  };
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
@@ -22,7 +38,11 @@ export default function ProfileScreen() {
         />
       }>
       <ThemedView style={styles.center}>
-        <GoogleLogin />
+        {loggedIn ? (
+          <Button title={t('profile.logout')} onPress={logout} />
+        ) : (
+          <GoogleLogin />
+        )}
         <Button title={t('profile.switchLanguage')} onPress={toggleLanguage} />
       </ThemedView>
     </ParallaxScrollView>

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -22,7 +22,8 @@
     "cancel": "Cancel"
   },
   "profile": {
-    "switchLanguage": "Switch Language"
+    "switchLanguage": "Switch Language",
+    "logout": "Logout"
   },
   "googleLogin": {
     "title": "Sign in with Google",

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -22,7 +22,8 @@
     "cancel": "Hủy"
   },
   "profile": {
-    "switchLanguage": "Chuyển ngôn ngữ"
+    "switchLanguage": "Chuyển ngôn ngữ",
+    "logout": "Đăng xuất"
   },
   "googleLogin": {
     "title": "Đăng nhập bằng Google",


### PR DESCRIPTION
## Summary
- add logout button and API call to mobile app profile tab
- wire logout button to ReadingHistoryContext
- update English and Vietnamese translations

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868be2fd060832885b35d01805dc178