### PR TITLE
Update native google login token handling

### DIFF
--- a/TangThuLauNative/components/GoogleLogin.tsx
+++ b/TangThuLauNative/components/GoogleLogin.tsx
@@ -25,10 +25,21 @@ export default observer(function GoogleLogin() {
     try {
       await GoogleSignin.hasPlayServices();
       const userInfo: any = await GoogleSignin.signIn();
-      await Api.post('/auth/google', {
+      const res = await Api.post('/auth/google', {
         token: userInfo.data?.idToken,
       });
-      await appStore.fetchProfile();
+
+      const { access_token, user } = res.data || {};
+
+      if (access_token) {
+        Api.defaults.headers.common['Authorization'] = `Bearer ${access_token}`;
+      }
+
+      if (user) {
+        appStore.profile = user;
+      } else {
+        await appStore.fetchProfile();
+      }
       syncWithServer();
     } catch (error: any) {
       console.error('❌ Lỗi đăng nhập:', error);

--- a/TangThuLauNative/utils/api.ts
+++ b/TangThuLauNative/utils/api.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 export const Api = axios.create({
   baseURL: API_BASE_URL,
-  // withCredentials: true,
+  withCredentials: true,
 });
 
 let isRefreshing = false;


### PR DESCRIPTION
## Summary
- allow axios API instance to send credentials
- on Google login success store access token in axios default header
- persist user profile in mobx store

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686934cc403c832885e5cd196bf83829