### PR TITLE
Fix localization for mobile

### DIFF
--- a/TangThuLauNative/app/+not-found.tsx
+++ b/TangThuLauNative/app/+not-found.tsx
@@ -3,15 +3,17 @@ import { StyleSheet } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { useTranslation } from '@/hooks/useTranslation';
 
 export default function NotFoundScreen() {
+  const { t } = useTranslation();
   return (
     <>
-      <Stack.Screen options={{ title: 'Oops!' }} />
+      <Stack.Screen options={{ title: t('notFound.title') }} />
       <ThemedView style={styles.container}>
-        <ThemedText type="title">This screen does not exist.</ThemedText>
+        <ThemedText type="title">{t('notFound.message')}</ThemedText>
         <Link href="/" style={styles.link}>
-          <ThemedText type="link">Go to home screen!</ThemedText>
+          <ThemedText type="link">{t('notFound.link')}</ThemedText>
         </Link>
       </ThemedView>
     </>

--- a/TangThuLauNative/components/GoogleLogin.tsx
+++ b/TangThuLauNative/components/GoogleLogin.tsx
@@ -42,8 +42,8 @@ export default observer(function GoogleLogin() {
       }
       syncWithServer();
     } catch (error: any) {
-      console.error('❌ Lỗi đăng nhập:', error);
-      Alert.alert('Lỗi', error.message);
+      console.error(`❌ ${t('errors.login_failed')}:`, error);
+      Alert.alert(t('errors.error'), error.message);
     }
   };
 

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -28,5 +28,14 @@
   "googleLogin": {
     "title": "Sign in with Google",
     "button": "Login with Google"
+  },
+  "notFound": {
+    "title": "Oops!",
+    "message": "This screen does not exist.",
+    "link": "Go to home screen!"
+  },
+  "errors": {
+    "error": "Error",
+    "login_failed": "Login failed"
   }
 }

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -28,5 +28,14 @@
   "googleLogin": {
     "title": "Đăng nhập bằng Google",
     "button": "Đăng nhập với Google"
+  },
+  "notFound": {
+    "title": "Rất tiếc!",
+    "message": "Màn hình này không tồn tại.",
+    "link": "Về trang chủ"
+  },
+  "errors": {
+    "error": "Lỗi",
+    "login_failed": "Lỗi đăng nhập"
   }
 }


### PR DESCRIPTION
## Summary
- localize NotFoundScreen and google login error messages
- add `notFound` and `errors` translations

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686943fbe61883288fb4e15d3a60339b