### PR TITLE
Add chapter sorting and card link

### DIFF
--- a/TangThuLauNative/app/story/[slug].tsx
+++ b/TangThuLauNative/app/story/[slug].tsx
@@ -1,0 +1,151 @@
+import { useLocalSearchParams } from 'expo-router';
+import { Image } from 'expo-image';
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { useTranslation } from '@/hooks/useTranslation';
+import { Api } from '@/utils/api';
+import { Chapter } from '@/types/Chapter';
+import { Story } from '@/types/Story';
+
+export default function StoryDetailScreen() {
+  const { slug } = useLocalSearchParams<{ slug: string }>();
+  const { t } = useTranslation();
+  const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<'asc' | 'desc'>('asc');
+  const limit = 20;
+
+  const { data: story, isLoading: loadingStory } = useQuery<Story>({
+    queryKey: ['story-detail', slug],
+    enabled: !!slug,
+    queryFn: async () => {
+      const res = await Api.get(`/stories/${slug}`);
+      return res.data;
+    },
+  });
+
+  const { data: chapters, isLoading: loadingChapters } = useQuery<{ data: Chapter[] }>({
+    queryKey: ['story-chapters', slug, page, sort],
+    enabled: !!slug,
+    queryFn: async () => {
+      const sortParam = sort === 'asc' ? 'chapterNumber' : '-chapterNumber';
+      const res = await Api.get(
+        `/stories/${slug}/chapters?page=${page}&limit=${limit}&sort=${sortParam}`,
+      );
+      return res.data;
+    },
+  });
+
+  const toggleSort = () => {
+    setSort((s) => (s === 'asc' ? 'desc' : 'asc'));
+    setPage(1);
+  };
+
+  if (loadingStory || !story) {
+    return (
+      <ThemedView style={styles.center}>
+        <ActivityIndicator />
+      </ThemedView>
+    );
+  }
+
+  const renderChapter = ({ item }: { item: Chapter }) => (
+    <ThemedText style={styles.chapterItem}>
+      {item.chapterNumber}. {item.title}
+    </ThemedText>
+  );
+
+  return (
+    <ScrollView>
+      <ThemedView style={styles.header}>
+        <Image
+          source={{ uri: story.cover }}
+          style={styles.cover}
+          contentFit="cover"
+        />
+        <ThemedText type="title" style={styles.title}>
+          {story.title}
+        </ThemedText>
+        <ThemedText style={styles.author}>{story.author?.name}</ThemedText>
+        <ThemedText style={styles.description}>{story.description}</ThemedText>
+      </ThemedView>
+      <View style={styles.chapterHeader}>
+        <ThemedText type="subtitle">{t('chapter.list')}</ThemedText>
+        <TouchableOpacity style={styles.sortBtn} onPress={toggleSort}>
+          <ThemedText style={styles.sortBtnText}>
+            {sort === 'asc' ? t('chapter.sort_desc') : t('chapter.sort_asc')}
+          </ThemedText>
+        </TouchableOpacity>
+      </View>
+      {loadingChapters ? (
+        <ActivityIndicator style={{ marginTop: 8 }} />
+      ) : (
+        <FlatList
+          data={chapters?.data || []}
+          keyExtractor={(item) => item._id}
+          renderItem={renderChapter}
+        />
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  header: {
+    padding: 16,
+  },
+  cover: {
+    width: '100%',
+    height: 200,
+    borderRadius: 8,
+    backgroundColor: '#ccc',
+  },
+  title: {
+    marginTop: 8,
+  },
+  author: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 4,
+  },
+  description: {
+    marginTop: 8,
+  },
+  chapterHeader: {
+    paddingHorizontal: 16,
+    marginTop: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  sortBtn: {
+    backgroundColor: '#0a7ea4',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+  },
+  sortBtnText: {
+    color: '#fff',
+  },
+  chapterItem: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: '#ccc',
+  },
+});

--- a/TangThuLauNative/components/StoryItem.tsx
+++ b/TangThuLauNative/components/StoryItem.tsx
@@ -1,14 +1,19 @@
 import { Image } from 'expo-image';
-import { View, Text, StyleSheet, ViewStyle } from 'react-native';
+import { View, Text, StyleSheet, ViewStyle, TouchableOpacity } from 'react-native';
+import { useRouter, Href } from 'expo-router';
 import { Story } from '@/types/Story';
 
 export default function StoryItem({ story, style }: { story: Story; style?: ViewStyle }) {
+  const router = useRouter();
   return (
-    <View style={[styles.container, style]}>
+    <TouchableOpacity
+      onPress={() => router.push(`/story/${story.slug}` as Href)}
+      style={[styles.container, style]}
+    >
       <Image source={{ uri: story.cover }} style={styles.cover} contentFit="cover" />
       <Text style={styles.title} numberOfLines={1}>{story.title}</Text>
       <Text style={styles.author} numberOfLines={1}>{story.author?.name}</Text>
-    </View>
+    </TouchableOpacity>
   );
 }
 

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -28,5 +28,10 @@
   "googleLogin": {
     "title": "Sign in with Google",
     "button": "Login with Google"
+  },
+  "chapter": {
+    "list": "Chapters",
+    "sort_asc": "Ascending",
+    "sort_desc": "Descending"
   }
 }

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -28,5 +28,10 @@
   "googleLogin": {
     "title": "Đăng nhập bằng Google",
     "button": "Đăng nhập với Google"
+  },
+  "chapter": {
+    "list": "Danh sách chương",
+    "sort_asc": "Tăng dần",
+    "sort_desc": "Giảm dần"
   }
 }

--- a/TangThuLauNative/types/Chapter.ts
+++ b/TangThuLauNative/types/Chapter.ts
@@ -1,0 +1,6 @@
+export interface Chapter {
+  _id: string;
+  slug: string;
+  title: string;
+  chapterNumber: number;
+}

--- a/backend/src/modules/chapter/chapter.service.ts
+++ b/backend/src/modules/chapter/chapter.service.ts
@@ -40,7 +40,7 @@ export class ChapterService {
   ) {}
 
   async getChapterList(slug: string, query: GetChapterListDto) {
-    const { page = 1, limit = 50 } = query;
+    const { page = 1, limit = 50, sort } = query;
     const story = await this.storyModel.findOne({ slug }).select('_id');
     if (!story) return { total: 0, page, limit, data: [] };
 
@@ -65,9 +65,13 @@ export class ChapterService {
       }
     }
 
+    const sortField = sort?.replace(/^-/, '') || 'chapterNumber';
+    const sortOrder = sort?.startsWith('-') ? -1 : 1;
+    const sortBy: any = { [sortField]: sortOrder };
+
     const data = await chapterModel
       .find(filter)
-      .sort({ chapterNumber: 1 })
+      .sort(sortBy)
       .skip((page - 1) * limit)
       .limit(limit)
       .select('title slug chapterNumber')

--- a/backend/src/modules/chapter/dto/get-chapter-list.dto.ts
+++ b/backend/src/modules/chapter/dto/get-chapter-list.dto.ts
@@ -13,4 +13,7 @@ export class GetChapterListDto {
   @IsNumber()
   @Min(1)
   limit = 50;
+
+  @IsOptional()
+  sort?: string;
 }

--- a/web-reader/components/story/StoryCard.tsx
+++ b/web-reader/components/story/StoryCard.tsx
@@ -16,8 +16,9 @@ export const StoryCard = observer(
     const WrapperComponent = isSlide ? "div" : ThreeDCardHover;
 
     return (
-      <div
+      <Link
         key={story._id}
+        href={`/truyen/${story.slug}`}
         className="grid w-full h-full place-items-center rounded-md"
       >
         <WrapperComponent
@@ -91,13 +92,13 @@ export const StoryCard = observer(
               </div>
             </CardBody>
             <CardFooter>
-              <Link href={`/truyen/${story.slug}`}>
+              <div className="mx-auto">
                 <NeonButtons.Lightning>{t("readNow")}</NeonButtons.Lightning>
-              </Link>
+              </div>
             </CardFooter>
           </Card>
         </WrapperComponent>
-      </div>
+      </Link>
     );
   },
 );

--- a/web-reader/components/story/StoryTabs.tsx
+++ b/web-reader/components/story/StoryTabs.tsx
@@ -6,6 +6,8 @@ import { Card, CardBody } from "@heroui/card";
 import Link from "next/link";
 import { Pagination } from "@heroui/pagination";
 import { useQuery } from "@tanstack/react-query";
+import { Button } from "@heroui/button";
+import { useTranslations } from "next-intl";
 
 import { ApiInstant } from "@/utils/api";
 
@@ -21,7 +23,9 @@ export function StoryTabs({
   description: string;
 }) {
   const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<'asc' | 'desc'>('asc');
   const limit = 20;
+  const t = useTranslations('chapter');
 
   // Fetch chapters via TanStack Query
   const {
@@ -29,10 +33,11 @@ export function StoryTabs({
     isLoading,
     isError,
   } = useQuery<any>({
-    queryKey: ["story-chapters", storySlug, page, limit],
+    queryKey: ["story-chapters", storySlug, page, limit, sort],
     queryFn: async () => {
+      const sortParam = sort === 'asc' ? 'chapterNumber' : '-chapterNumber';
       const res = await ApiInstant.get(
-        `/stories/${storySlug}/chapters?page=${page}&limit=${limit}`,
+        `/stories/${storySlug}/chapters?page=${page}&limit=${limit}&sort=${sortParam}`,
       );
 
       return res.data;
@@ -65,7 +70,19 @@ export function StoryTabs({
         </Tab>
         <Tab key="chapters" title="Danh sách chương">
           <CardBody>
-            <h2 className="text-xl font-semibold mb-4">Danh sách chương</h2>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-semibold">Danh sách chương</h2>
+              <Button
+                onClick={() => {
+                  setSort((s) => (s === 'asc' ? 'desc' : 'asc'));
+                  setPage(1);
+                }}
+                size="sm"
+                variant="light"
+              >
+                {sort === 'asc' ? t('sort_desc') : t('sort_asc')}
+              </Button>
+            </div>
             {isLoading ? (
               <div className="py-8 text-center text-default-400">
                 Đang tải chương...

--- a/web-reader/messages/en.json
+++ b/web-reader/messages/en.json
@@ -48,7 +48,9 @@
     "choose_text_color": "Choose text color {color}",
     "audio_speed": "Audio speed",
     "chapter_loading": "Chapter is loading",
-    "watch_on_source": "View on source"
+    "watch_on_source": "View on source",
+    "sort_asc": "Ascending",
+    "sort_desc": "Descending"
   },
   "story": {
     "author": "Author",

--- a/web-reader/messages/vi.json
+++ b/web-reader/messages/vi.json
@@ -48,7 +48,9 @@
     "choose_text_color": "Chọn màu chữ {color}",
     "audio_speed": "Tốc độ đọc",
     "chapter_loading": "Nội dung chương lỗi",
-    "watch_on_source": "Xem trực tiếp tại nguồn"
+    "watch_on_source": "Xem trực tiếp tại nguồn",
+    "sort_asc": "Tăng dần",
+    "sort_desc": "Giảm dần"
   },
   "story": {
     "author": "Tác giả",


### PR DESCRIPTION
## Summary
- make entire story card clickable
- allow sorting chapter list in backend
- add sorting controls in story detail page
- add translation strings for sorting

## Testing
- `npm run lint` (fails: Cannot find package 'eslint')
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_686944c9c5f483288eff30c7cd90ec6d