### PR TITLE
Localize home and search pages

### DIFF
--- a/web-reader/app/page.tsx
+++ b/web-reader/app/page.tsx
@@ -1,4 +1,16 @@
 import LazyHomePage from "./LazyHomePage";
+import { headers } from "next/headers";
+import { createTranslator, getMessages } from "next-intl/server";
+
+export async function generateMetadata() {
+  const locale = headers().get("x-next-intl-locale") || "vi";
+  const messages = await getMessages({ locale });
+  const t = createTranslator({ locale, messages, namespace: "home" });
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function HomePage() {
   return <LazyHomePage />;

--- a/web-reader/app/search/page.tsx
+++ b/web-reader/app/search/page.tsx
@@ -1,12 +1,18 @@
 import { Suspense } from "react";
+import { headers } from "next/headers";
+import { createTranslator, getMessages } from "next-intl/server";
 import { useTranslations } from "next-intl";
 
 import LazySearchPage from "./LazySearchPage";
-export const metadata = {
-  title: "Tìm kiếm truyện hay | Vô Ưu Các",
-  description:
-    "Tìm kiếm truyện tiên hiệp, kiếm hiệp, huyền huyễn hấp dẫn theo từ khóa, thể loại, tác giả hoặc số chương.",
-};
+export async function generateMetadata() {
+  const locale = headers().get("x-next-intl-locale") || "vi";
+  const messages = await getMessages({ locale });
+  const t = createTranslator({ locale, messages, namespace: "search" });
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
 
 export default function Page() {
   const t = useTranslations("search");

--- a/web-reader/messages/en.json
+++ b/web-reader/messages/en.json
@@ -27,6 +27,8 @@
     "most_viewed": "Most Viewed Stories",
     "most_liked": "Most Liked Stories",
     "longest": "Longest Stories"
+    ,"title": "Vo Uu Cac - Xianxia space"
+    ,"description": "Discover top recommended, most viewed and longest stories."
   },
   "chapter": {
     "loading": "Loading chapter...",

--- a/web-reader/messages/vi.json
+++ b/web-reader/messages/vi.json
@@ -27,6 +27,8 @@
     "most_viewed": "Truyện Đọc Nhiều",
     "most_liked": "Truyện nhiều yêu thích",
     "longest": "Truyện dài nhất"
+    ,"title": "Vô Ưu Các - Không gian tiên hiệp"
+    ,"description": "Khám phá truyện đề cử, đọc nhiều và dài nhất."
   },
   "chapter": {
     "loading": "Đang tải chương...",


### PR DESCRIPTION
## Summary
- add home page metadata translations
- add localized metadata to home page
- add localized metadata to search page

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6869489e80a48328813e12fb22eec3e4