### PR TITLE
Localize search input placeholder

### DIFF
--- a/TangThuLauNative/app/(tabs)/search.tsx
+++ b/TangThuLauNative/app/(tabs)/search.tsx
@@ -77,7 +77,7 @@ export default function SearchScreen() {
       }>
       <ThemedView style={styles.form}>
         <TextInput
-          placeholder={t('home.search_placeholder')}
+          placeholder={t('search.search_placeholder')}
           value={keyword}
           onChangeText={setKeyword}
           style={styles.input}

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -19,7 +19,8 @@
     "category": "Category",
     "author": "Author",
     "search": "Search",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "search_placeholder": "Search stories..."
   },
   "profile": {
     "switchLanguage": "Switch Language",

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -19,7 +19,8 @@
     "category": "Thể loại",
     "author": "Tác giả",
     "search": "Tìm kiếm",
-    "cancel": "Hủy"
+    "cancel": "Hủy",
+    "search_placeholder": "Tìm kiếm truyện..."
   },
   "profile": {
     "switchLanguage": "Chuyển ngôn ngữ",


### PR DESCRIPTION
## Summary
- localize search page placeholder
- add `search.search_placeholder` key in English and Vietnamese translations

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686949ee683c8328981fcb0b4725a3ae