### PR TITLE
Show account profile

### DIFF
--- a/TangThuLauNative/app/(tabs)/profile.tsx
+++ b/TangThuLauNative/app/(tabs)/profile.tsx
@@ -68,11 +68,18 @@ export default observer(function ProfileScreen() {
       headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
       headerImage={
         <Image
-          source={require('@/assets/images/partial-react-logo.png')}
+          source={
+            appStore.auth.profile?.photo
+              ? { uri: appStore.auth.profile.photo }
+              : require('@/assets/images/partial-react-logo.png')
+          }
           style={styles.reactLogo}
         />
       }>
       <ThemedView style={styles.profileInfo}>
+        {appStore.auth.profile?.photo && (
+          <Image source={{ uri: appStore.auth.profile.photo }} style={styles.avatar} />
+        )}
         <ThemedText type="title">
           {appStore.auth.profile?.name || appStore.auth.profile?.email || 'Guest'}
         </ThemedText>
@@ -125,6 +132,13 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderColor: '#ccc',
     paddingTop: 12,
+  },
+  avatar: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    marginBottom: 12,
+    backgroundColor: '#ccc',
   },
   reactLogo: {
     height: 178,

--- a/TangThuLauNative/app/(tabs)/profile.tsx
+++ b/TangThuLauNative/app/(tabs)/profile.tsx
@@ -1,5 +1,6 @@
 import { Image } from 'expo-image';
 import { Alert, Button, StyleSheet, View } from 'react-native';
+import { useEffect } from 'react';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
 
 import ParallaxScrollView from '@/components/ParallaxScrollView';
@@ -16,6 +17,12 @@ export default observer(function ProfileScreen() {
   const appStore = useAppStore();
   const { t } = useTranslation();
   const { loggedIn, syncWithServer } = useReadingHistory();
+
+  useEffect(() => {
+    if (!appStore.auth.profile) {
+      appStore.auth.fetchProfile();
+    }
+  }, []);
 
   GoogleSignin.configure({
     webClientId: envConfig.GOOGLE_CLIENT_ID_FOR_WEB,
@@ -71,6 +78,19 @@ export default observer(function ProfileScreen() {
         </ThemedText>
         {appStore.auth.profile?.email && (
           <ThemedText>{appStore.auth.profile.email}</ThemedText>
+        )}
+        {appStore.auth.profile && (
+          <>
+            <ThemedText>
+              {t('profile.role')}: {appStore.auth.profile.role?.name || appStore.auth.profile.role}
+            </ThemedText>
+            <ThemedText>
+              {t('profile.level')}: {appStore.auth.profile.level}
+            </ThemedText>
+            <ThemedText>
+              {t('profile.coin')}: {appStore.auth.profile.coin}
+            </ThemedText>
+          </>
         )}
       </ThemedView>
       <View style={styles.menu}>

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -23,7 +23,7 @@
     "search_placeholder": "Search stories..."
   },
   "profile": {
-    "switchLanguage": "Switch Language",
+    "switchLanguage": "Vietnamese",
     "logout": "Logout",
     "level": "Level",
     "coin": "Coin",

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -24,7 +24,10 @@
   },
   "profile": {
     "switchLanguage": "Switch Language",
-    "logout": "Logout"
+    "logout": "Logout",
+    "level": "Level",
+    "coin": "Coin",
+    "role": "Role"
   },
   "googleLogin": {
     "title": "Sign in with Google",

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -23,7 +23,7 @@
     "search_placeholder": "Tìm kiếm truyện..."
   },
   "profile": {
-    "switchLanguage": "Chuyển ngôn ngữ",
+    "switchLanguage": "Tiếng Anh",
     "logout": "Đăng xuất",
     "level": "Cấp",
     "coin": "Xu",

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -24,7 +24,10 @@
   },
   "profile": {
     "switchLanguage": "Chuyển ngôn ngữ",
-    "logout": "Đăng xuất"
+    "logout": "Đăng xuất",
+    "level": "Cấp",
+    "coin": "Xu",
+    "role": "Vai trò"
   },
   "googleLogin": {
     "title": "Đăng nhập bằng Google",

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -233,6 +233,7 @@ export class AuthService {
       user: {
         _id: user._id,
         name: user.name,
+        photo: user.photo,
         email: user.email,
         role: payload.role,
       },

--- a/backend/src/modules/auth/mappers/UserDataAndUserResponseMapper.ts
+++ b/backend/src/modules/auth/mappers/UserDataAndUserResponseMapper.ts
@@ -8,6 +8,7 @@ export class UserDataAndUserResponseMapper {
     return {
       email: userData.email,
       name: userData.name,
+      photo: userData.photo,
       exp: userData.exp,
       banned: userData.banned,
       coin: userData.coin,


### PR DESCRIPTION
## Summary
- fetch user profile if missing
- display role, level and coin on the profile tab
- add translations for the new profile fields

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695eb593088328b2f38f6d05bce8ee