### PR TITLE
Add password change functionality

### DIFF
--- a/TangThuLauNative/app/(tabs)/profile.tsx
+++ b/TangThuLauNative/app/(tabs)/profile.tsx
@@ -1,5 +1,6 @@
 import { Image } from 'expo-image';
 import { Alert, Button, StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
 import { useEffect } from 'react';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
 
@@ -16,6 +17,7 @@ import { envConfig } from '@/constants/env';
 export default observer(function ProfileScreen() {
   const appStore = useAppStore();
   const { t } = useTranslation();
+  const router = useRouter();
   const { loggedIn, syncWithServer } = useReadingHistory();
 
   useEffect(() => {
@@ -92,10 +94,10 @@ export default observer(function ProfileScreen() {
               {t('profile.role')}: {appStore.auth.profile.role?.name || appStore.auth.profile.role}
             </ThemedText>
             <ThemedText>
-              {t('profile.level')}: {appStore.auth.profile.level}
+              {t('profile.level')}: {appStore.auth.profile?.level ?? 0}
             </ThemedText>
             <ThemedText>
-              {t('profile.coin')}: {appStore.auth.profile.coin}
+              {t('profile.coin')}: {appStore.auth.profile?.coin ?? 0}
             </ThemedText>
           </>
         )}
@@ -107,6 +109,14 @@ export default observer(function ProfileScreen() {
             onPress={appStore.locale.toggleLanguage}
           />
         </View>
+        {loggedIn && (
+          <View style={styles.menuItem}>
+            <Button
+              title={t('changePassword.title')}
+              onPress={() => router.push('/change-password')}
+            />
+          </View>
+        )}
         <View style={[styles.menuItem, styles.loginItem]}>
           {loggedIn ? (
             <Button title={t('profile.logout')} onPress={logout} color="red" />

--- a/TangThuLauNative/app/change-password.tsx
+++ b/TangThuLauNative/app/change-password.tsx
@@ -1,0 +1,57 @@
+import { Stack, useRouter } from 'expo-router';
+import { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+
+import { ThemedText } from '@/components/ThemedText';
+import { useTranslation } from '@/hooks/useTranslation';
+import { Api } from '@/utils/api';
+
+export default function ChangePasswordScreen() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+
+  const submit = async () => {
+    try {
+      await Api.post('/auth/change-password', {
+        currentPassword,
+        newPassword,
+      });
+      router.back();
+    } catch (e) {
+      console.warn('Change password error', e);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: t('changePassword.title') }} />
+      <TextInput
+        style={styles.input}
+        placeholder={t('changePassword.current_password')}
+        secureTextEntry
+        value={currentPassword}
+        onChangeText={setCurrentPassword}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder={t('changePassword.new_password')}
+        secureTextEntry
+        value={newPassword}
+        onChangeText={setNewPassword}
+      />
+      <Button title={t('changePassword.submit')} onPress={submit} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, gap: 12 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    borderRadius: 4,
+  },
+});

--- a/TangThuLauNative/localization/en.json
+++ b/TangThuLauNative/localization/en.json
@@ -29,6 +29,12 @@
     "coin": "Coin",
     "role": "Role"
   },
+  "changePassword": {
+    "title": "Change password",
+    "current_password": "Current password",
+    "new_password": "New password",
+    "submit": "Change"
+  },
   "googleLogin": {
     "title": "Sign in with Google",
     "button": "Login with Google"

--- a/TangThuLauNative/localization/vi.json
+++ b/TangThuLauNative/localization/vi.json
@@ -29,6 +29,12 @@
     "coin": "Xu",
     "role": "Vai trò"
   },
+  "changePassword": {
+    "title": "Đổi mật khẩu",
+    "current_password": "Mật khẩu hiện tại",
+    "new_password": "Mật khẩu mới",
+    "submit": "Đổi"
+  },
   "googleLogin": {
     "title": "Đăng nhập bằng Google",
     "button": "Đăng nhập với Google"

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -16,6 +16,7 @@ import { CurrentUser } from './decorators/current-user.decorator';
 import { ForgotPasswordDto } from './dto/forgot-password.dto';
 import { RegisterDto } from './dto/register.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
 import { Throttle } from '@nestjs/throttler';
 import { Roles } from './decorators/roles.decorator';
 import { RoleSlug } from '@/constants/role.enum';
@@ -142,6 +143,19 @@ export class AuthController {
   @Post('reset-password')
   async resetPassword(@Body() dto: ResetPasswordDto) {
     return await this.authService.resetPassword(dto.token, dto.newPassword);
+  }
+
+  @Roles(RoleSlug.READER, RoleSlug.ADMIN, RoleSlug.SUPER_ADMIN)
+  @Post('change-password')
+  async changePassword(
+    @CurrentUser('userId') userId: string,
+    @Body() dto: ChangePasswordDto,
+  ) {
+    return await this.authService.changePassword(
+      userId,
+      dto.currentPassword,
+      dto.newPassword,
+    );
   }
 
   @Public()

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -200,6 +200,26 @@ export class AuthService {
     }
   }
 
+  async changePassword(
+    userId: string,
+    currentPassword: string,
+    newPassword: string,
+  ) {
+    const user = await this.userModel.findById(userId);
+    if (!user) throw new UnauthorizedException('User không tồn tại');
+
+    const isMatch = await bcrypt.compare(currentPassword, user.password);
+    if (!isMatch) throw new UnauthorizedException('Mật khẩu hiện tại không đúng');
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+    await this.userModel.findByIdAndUpdate(userId, {
+      password: hashed,
+      refreshToken: null,
+    });
+
+    return { message: 'Đổi mật khẩu thành công' };
+  }
+
   private buildPayload(user: any) {
     return {
       sub: user._id.toString(),

--- a/backend/src/modules/auth/dto/change-password.dto.ts
+++ b/backend/src/modules/auth/dto/change-password.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @IsNotEmpty()
+  currentPassword: string;
+
+  @MinLength(6)
+  newPassword: string;
+}

--- a/web-reader/app/profile/change-password/LazyChangePasswordPage.tsx
+++ b/web-reader/app/profile/change-password/LazyChangePasswordPage.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const ChangePasswordPageContent = dynamic(
+  () => import("@/components/profile/ChangePasswordPageContent"),
+  { ssr: false },
+);
+
+const LazyChangePasswordPage = (props: any) => {
+  return <ChangePasswordPageContent {...props} />;
+};
+
+export default LazyChangePasswordPage;

--- a/web-reader/app/profile/change-password/head.tsx
+++ b/web-reader/app/profile/change-password/head.tsx
@@ -1,0 +1,4 @@
+export const metadata = {
+  title: "Đổi mật khẩu | Vô Ưu Các",
+  description: "Thay đổi mật khẩu tài khoản của bạn.",
+};

--- a/web-reader/app/profile/change-password/page.tsx
+++ b/web-reader/app/profile/change-password/page.tsx
@@ -1,0 +1,5 @@
+import LazyChangePasswordPage from "./LazyChangePasswordPage";
+
+export default function ChangePasswordPage() {
+  return <LazyChangePasswordPage />;
+}

--- a/web-reader/components/game/PlayerPanel.tsx
+++ b/web-reader/components/game/PlayerPanel.tsx
@@ -49,15 +49,15 @@ export const PlayerPanel = observer(() => {
               </div>
               <div className="flex w-full flex-col bg-slate-500 rounded-md p-4">
                 <div className="font-bold text-red-700 text-center">
-                  {getLevelName(store.auth.profile.level)}
+                  {getLevelName(store.auth.profile?.level ?? 0)}
                 </div>
                 <div className="mt-2 font-bold text-gray-950 inline-flex justify-between items-center w-full px-4">
                   <div>{t("exp")}:</div>
-                  <div>{store.auth.profile.exp}</div>
+                  <div>{store.auth.profile?.exp ?? 0}</div>
                 </div>
                 <div className="font-bold text-gray-950 inline-flex justify-between items-center w-full px-4">
                   <div>{t("coin")}:</div>
-                  <div>{store.auth.profile.coin}</div>
+                  <div>{store.auth.profile?.coin ?? 0}</div>
                 </div>
               </div>
             </div>

--- a/web-reader/components/profile/ChangePasswordPageContent.tsx
+++ b/web-reader/components/profile/ChangePasswordPageContent.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "@heroui/input";
+import { Button } from "@heroui/button";
+import { useTranslations } from "next-intl";
+import { ApiInstant } from "@/utils/api";
+import { useRouter } from "next/navigation";
+
+function ChangePasswordPageContent() {
+  const t = useTranslations("changePassword");
+  const router = useRouter();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await ApiInstant.post("/auth/change-password", {
+        currentPassword,
+        newPassword,
+      });
+      router.back();
+    } catch (err) {
+      console.error("change password error", err);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto px-4 py-10 space-y-6">
+      <h1 className="text-2xl font-bold">{t("title")}</h1>
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <Input
+          isRequired
+          label={t("current_password")}
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+        />
+        <Input
+          isRequired
+          label={t("new_password")}
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+        />
+        <Button color="primary" role="button" type="submit">
+          {t("submit")}
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+export default ChangePasswordPageContent;

--- a/web-reader/components/profile/ProfilePageContent.tsx
+++ b/web-reader/components/profile/ProfilePageContent.tsx
@@ -20,6 +20,7 @@ const PAGE_SIZE = 20;
 
 function ProfilePageContent() {
   const t = useTranslations("profile");
+  const tChange = useTranslations("changePassword");
   const [readItems, setReadItems] = useState<ReadItem[]>([]);
   const [page, setPage] = useState(1);
   const appStore = useAppStore();
@@ -70,15 +71,26 @@ function ProfilePageContent() {
         {appStore.auth.profile && (
           <div className="flex flex-col items-end gap-4 ">
             <div className="flex flex-row items-center">
-              <span>{t("exp")}</span>: {appStore.auth.profile.exp || 0}
+              <span>{t("exp")}</span>:{" "}
+              {appStore.auth.profile?.exp ?? 0}
             </div>
             <div className="flex flex-row items-center">
-              <span>{t("level")}</span>: {appStore.auth.profile.level || 1}
+              <span>{t("level")}</span>:{" "}
+              {appStore.auth.profile?.level ?? 0}
             </div>
             <div className="flex flex-row items-center">
-              <span>{t("coin")}</span>: {appStore.auth.profile.coin || 0}
+              <span>{t("coin")}</span>:{" "}
+              {appStore.auth.profile?.coin ?? 0}
             </div>
           </div>
+        )}
+        {appStore.auth.profile && (
+          <Link
+            href="/profile/change-password"
+            className="text-sm text-blue-600 underline"
+          >
+            {tChange("title")}
+          </Link>
         )}
       </div>
 

--- a/web-reader/messages/en.json
+++ b/web-reader/messages/en.json
@@ -111,6 +111,12 @@
     "user_info": "Player Information",
     "loading": "Loading..."
   },
+  "changePassword": {
+    "title": "Change password",
+    "current_password": "Current password",
+    "new_password": "New password",
+    "submit": "Change"
+  },
   "docs": {
     "title": "Documentation"
   },

--- a/web-reader/messages/vi.json
+++ b/web-reader/messages/vi.json
@@ -111,6 +111,12 @@
     "user_info": "Thông tin người chơi",
     "loading": "Đang tải ..."
   },
+  "changePassword": {
+    "title": "Đổi mật khẩu",
+    "current_password": "Mật khẩu hiện tại",
+    "new_password": "Mật khẩu mới",
+    "submit": "Đổi"
+  },
   "docs": {
     "title": "Tài liệu"
   },


### PR DESCRIPTION
## Summary
- show zero level/coin correctly in profile views
- implement change password API in backend
- add change password page and button for web-reader
- add change password screen for TangThuLauNative
- update localizations

## Testing
- `npm test` in backend *(fails: jest not found)*
- `npm run lint` in web-reader *(fails: ESLint missing)*
- `npm run lint` in TangThuLauNative *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686965219e0c832890ca52b5556ac971